### PR TITLE
feat(next): export `configureServerLogger` from public API

### DIFF
--- a/packages/vestig-next/src/index.ts
+++ b/packages/vestig-next/src/index.ts
@@ -36,7 +36,13 @@
  */
 
 // Server Components
-export { getLogger, getRequestContext, createChildLogger } from './server/server-component'
+export {
+	getLogger,
+	getRequestContext,
+	createChildLogger,
+	configureServerLogger,
+} from './server/server-component'
+export type { ServerLoggerOptions } from './server/server-component'
 
 // Route Handlers
 export { withVestig, createRouteHandlers } from './server/route-handler'


### PR DESCRIPTION
## Summary

`configureServerLogger` and `ServerLoggerOptions` already exist in `server-component.ts` but were not exported from the package's main entry point (`@vestig/next`). This meant users could not customize the server logger's namespace, level, structured mode, etc. without copying the internal module.

This PR adds both to the public exports — a non-breaking, additive change. Existing users who don't call `configureServerLogger` get the same defaults as today.

### Changes

- **`packages/vestig-next/src/index.ts`**: Added `configureServerLogger` to the runtime exports and `ServerLoggerOptions` to the type exports from `./server/server-component`

### Usage after this change

```typescript
import { configureServerLogger } from '@vestig/next'
import type { LogLevel } from 'vestig'

configureServerLogger({
  namespace: 'web',
  level: (process.env.LOG_LEVEL || 'info') as LogLevel,
  structured: undefined, // auto-detect from NODE_ENV
})
```

Fixes #4

---

Thank you for the great work on Vestig! This was likely just an oversight — the function was clearly designed to be user-facing (it has JSDoc, proper interface, etc.) but just wasn't wired up in the barrel export.